### PR TITLE
Support reading and writing from stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 *.dat
 *.json
 !package.json
+yarn.lock


### PR DESCRIPTION
Allows the user to pipe input to nbt-dump instead of providing an input file. Useful if the input is coming from another terminal task, such as decoding nbt from base64.

For example:
```
echo 'CgAAAwgAYmxvY2tfaWTbAwAACAQAbmFtZRkAbWluZWNyYWZ0OmN5YW5fdGVycmFjb3R0YQQJAG5hbWVfaGFzaN09COzMuHwAAwoAbmV0d29ya19pZIWPCzoKBgBzdGF0ZXMAAwcAdmVyc2lvbgRGFAEA' | base64 --decode | nbt-dump
```